### PR TITLE
Require PHP 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 		}
 	],
 	"require"          : {
+		"php": "5.4",
 		"silverstripe/framework"              : "~3.1",
 		"phpmailer/phpmailer"                 : "~5.2",
 		"guzzlehttp/guzzle"                   : "~4",


### PR DESCRIPTION
As `[]` notation is used for arrays, 5.4+ is required.
